### PR TITLE
[Companion] Feat/3 murmur api create functions that interact with murmur core

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,9 +114,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("✅ MMR proxy account creation successful!");
         }
         Commands::Execute(args) => {
-            // build balance transfer
-            // let bob = dev::alice().public_key();
-            // let to_bytes: [u8; 32] = args.to.as_bytes().to_vec().try_into().unwrap();
             let from_ss58 = sp_core::crypto::AccountId32::from_ss58check(&args.to)
                 .unwrap();
 
@@ -137,8 +134,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let target_block_number: BlockNumber = current_block_number + 1;
             println!("💾 Recovered Murmur store from local file");
             let tx = prepare_execute(
-                args.name.clone().as_bytes().to_vec(),
-                args.seed.clone().as_bytes().to_vec(),
+                args.name.clone(),
+                args.seed.clone(),
                 target_block_number,
                 store,
                 balance_transfer_call,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -93,14 +93,14 @@ pub fn create(
 /// * `call`: Any valid runtime call
 ///
 pub async fn prepare_execute(
-    name: Vec<u8>,
-    seed: Vec<u8>,
+    name: String,
+    seed: String,
     when: BlockNumber,
     store: MurmurStore,
     call: RuntimeCall,
 ) -> TxPayload<Proxy> {
     let (proof, commitment, ciphertext, pos) =
-        store.execute(seed.clone(), when, call.encode()).unwrap();
+        store.execute(seed.clone().into(), when, call.encode()).unwrap();
     let size: u64 = proof.mmr_size();
     let proof_items: Vec<Vec<u8>> = proof
         .proof_items()
@@ -109,7 +109,7 @@ pub async fn prepare_execute(
         .collect::<Vec<_>>();
 
     etf::tx().murmur().proxy(
-        BoundedVec(name),
+        BoundedVec(name.into()),
         pos,
         commitment,
         ciphertext,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,18 +15,16 @@
  */
 
 use beefy::{known_payloads, Commitment, Payload};
-use murmur_core::{
-    types::{Identity, IdentityBuilder},
-};
-pub use murmur_core::types::BlockNumber;
-pub use murmur_core::murmur::MurmurStore;
-use etf::murmur::calls::types::{Create, Proxy};
 use etf::runtime_types::{
-    bounded_collections::bounded_vec::BoundedVec,
-    node_template_runtime::RuntimeCall,
+    bounded_collections::bounded_vec::BoundedVec, node_template_runtime::RuntimeCall,
 };
+use murmur_core::types::{Identity, IdentityBuilder};
 use subxt::ext::codec::Encode;
 use w3f_bls::{DoublePublicKey, SerializableToBytes, TinyBLS377};
+
+pub use etf::murmur::calls::types::{Create, Proxy};
+pub use murmur_core::{murmur::MurmurStore, types::BlockNumber};
+pub use subxt::tx::Payload as TxPayload;
 
 // Generate an interface that we can use from the node's metadata.
 #[subxt::subxt(runtime_metadata_path = "artifacts/metadata.scale")]
@@ -61,7 +59,7 @@ pub fn create(
     ephem_msk: [u8; 32],
     block_schedule: Vec<BlockNumber>,
     round_pubkey_bytes: Vec<u8>,
-) -> (subxt::tx::Payload<Create>, MurmurStore) {
+) -> (TxPayload<Create>, MurmurStore) {
     let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap(); // TODO: error handlking
     let mmr_store = MurmurStore::new::<TinyBLS377, BasicIdBuilder>(
         seed.clone().into(),
@@ -100,7 +98,7 @@ pub async fn prepare_execute(
     when: BlockNumber,
     store: MurmurStore,
     call: RuntimeCall,
-) -> subxt::tx::Payload<Proxy> {
+) -> TxPayload<Proxy> {
     let (proof, commitment, ciphertext, pos) =
         store.execute(seed.clone(), when, call.encode()).unwrap();
     let size: u64 = proof.mmr_size();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -19,7 +19,9 @@ use etf::runtime_types::{
     bounded_collections::bounded_vec::BoundedVec, node_template_runtime::RuntimeCall,
 };
 use murmur_core::types::{Identity, IdentityBuilder};
-use subxt::ext::codec::Encode;
+use subxt::{
+    backend::rpc::RpcClient, client::OnlineClient, config::SubstrateConfig, ext::codec::Encode,
+};
 use w3f_bls::{DoublePublicKey, SerializableToBytes, TinyBLS377};
 
 pub use etf::murmur::calls::types::{Create, Proxy};
@@ -99,8 +101,9 @@ pub async fn prepare_execute(
     store: MurmurStore,
     call: RuntimeCall,
 ) -> TxPayload<Proxy> {
-    let (proof, commitment, ciphertext, pos) =
-        store.execute(seed.clone().into(), when, call.encode()).unwrap();
+    let (proof, commitment, ciphertext, pos) = store
+        .execute(seed.clone().into(), when, call.encode())
+        .unwrap();
     let size: u64 = proof.mmr_size();
     let proof_items: Vec<Vec<u8>> = proof
         .proof_items()
@@ -117,4 +120,41 @@ pub async fn prepare_execute(
         size,
         call,
     )
+}
+
+/// Async connection to the Ideal Network
+/// if successful then fetch data
+/// else error if unreachable
+pub async fn idn_connect(
+) -> Result<(OnlineClient<SubstrateConfig>, BlockNumber, Vec<u8>), Box<dyn std::error::Error>> {
+    println!("🎲 Connecting to Ideal network (local node)");
+    let ws_url = std::env::var("WS_URL").unwrap_or_else(|_| {
+        let fallback_url = "ws://localhost:9944".to_string();
+        println!(
+            "⚠️ WS_URL environment variable not set. Using fallback URL: {}",
+            fallback_url
+        );
+        fallback_url
+    });
+
+    let rpc_client = RpcClient::from_url(&ws_url).await?;
+    let client = OnlineClient::<SubstrateConfig>::from_rpc_client(rpc_client.clone()).await?;
+    println!("🔗 RPC Client: connection established");
+
+    // fetch the round public key from etf runtime storage
+    let round_key_query = subxt::dynamic::storage("Etf", "RoundPublic", ());
+    let result = client
+        .storage()
+        .at_latest()
+        .await?
+        .fetch(&round_key_query)
+        .await?;
+    let round_pubkey_bytes = result.unwrap().as_type::<Vec<u8>>()?;
+
+    println!("🔑 Successfully retrieved the round public key.");
+
+    let current_block = client.blocks().at_latest().await?;
+    let current_block_number: BlockNumber = current_block.header().number;
+    println!("🧊 Current block number: #{:?}", current_block_number);
+    Ok((client, current_block_number, round_pubkey_bytes))
 }


### PR DESCRIPTION
companion for https://github.com/ideal-lab5/murmur-api/pull/5

- Adds some reexports in the `lib`
- Makes `execute` and `new` functions accept the same `name` and `seed` types
- Moves `idn_connect` to the `lib`